### PR TITLE
update compiler version

### DIFF
--- a/src/base/Multicall.sol
+++ b/src/base/Multicall.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-pragma solidity ^0.8.2;
+pragma solidity ^0.8.0;
 
 import {IMulticall} from "../interfaces/IMulticall.sol";
 

--- a/src/lens/RelayOrderQuoter.sol
+++ b/src/lens/RelayOrderQuoter.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-pragma solidity ^0.8.2;
+pragma solidity 0.8.24;
 
 import {SignedOrder} from "UniswapX/src/base/ReactorStructs.sol";
 import {ResolvedInput} from "../base/ReactorStructs.sol";

--- a/src/lib/ActionsLib.sol
+++ b/src/lib/ActionsLib.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-pragma solidity ^0.8.2;
+pragma solidity ^0.8.0;
 
 /// @notice Handles all calls to the universal router.
 library ActionsLib {

--- a/src/lib/RelayDecayLib.sol
+++ b/src/lib/RelayDecayLib.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-pragma solidity ^0.8.2;
+pragma solidity ^0.8.0;
 
 import {FixedPointMathLib} from "solmate/src/utils/FixedPointMathLib.sol";
 

--- a/src/lib/RelayOrderLib.sol
+++ b/src/lib/RelayOrderLib.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-pragma solidity ^0.8.2;
+pragma solidity ^0.8.0;
 
 import {IPermit2} from "permit2/src/interfaces/IPermit2.sol";
 import {ISignatureTransfer} from "permit2/src/interfaces/ISignatureTransfer.sol";

--- a/src/reactors/RelayOrderReactor.sol
+++ b/src/reactors/RelayOrderReactor.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-pragma solidity ^0.8.2;
+pragma solidity 0.8.24;
 
 import {IPermit2} from "permit2/src/interfaces/IPermit2.sol";
 import {Permit2Lib} from "permit2/src/libraries/Permit2Lib.sol";

--- a/test/foundry-tests/util/Constants.sol
+++ b/test/foundry-tests/util/Constants.sol
@@ -1,4 +1,4 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-pragma solidity ^0.8.2;
+pragma solidity ^0.8.0;
 
 uint256 constant ONE = 10 ** 18;

--- a/test/foundry-tests/util/InputBuilder.sol
+++ b/test/foundry-tests/util/InputBuilder.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-pragma solidity ^0.8.2;
+pragma solidity ^0.8.0;
 
 import {Input} from "../../../src/base/ReactorStructs.sol";
 import {IRelayOrderReactor} from "../../../src/interfaces/IRelayOrderReactor.sol";

--- a/test/foundry-tests/util/Interop.sol
+++ b/test/foundry-tests/util/Interop.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.17;
+pragma solidity ^0.8.0;
 
 import {Test, stdJson} from "forge-std/Test.sol";
 

--- a/test/foundry-tests/util/OrderInfoBuilder.sol
+++ b/test/foundry-tests/util/OrderInfoBuilder.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-pragma solidity ^0.8.2;
+pragma solidity ^0.8.0;
 
 import {OrderInfo} from "../../../src/base/ReactorStructs.sol";
 import {IRelayOrderReactor} from "../../../src/interfaces/IRelayOrderReactor.sol";

--- a/test/foundry-tests/util/RelayOrderBuilder.sol
+++ b/test/foundry-tests/util/RelayOrderBuilder.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-pragma solidity ^0.8.2;
+pragma solidity ^0.8.0;
 
 import {Input, OrderInfo, RelayOrder} from "../../../src/base/ReactorStructs.sol";
 import {IRelayOrderReactor} from "../../../src/interfaces/IRelayOrderReactor.sol";


### PR DESCRIPTION
Pins the version for Reactor and Quoter at 0.8.24
Uses ^0.8.0 for interfaces, libs, and abstract contracts